### PR TITLE
Fix battery recharge dialog action

### DIFF
--- a/gui/dialogs/dragrobot.xml
+++ b/gui/dialogs/dragrobot.xml
@@ -14,7 +14,7 @@
 			<stretch>true</stretch>
 		</empty>
 		<text>
-			<label>Drag Roboter Configuration</label>
+			<label>Drag Robot Configuration</label>
 			<font>
 				<name>times_bold</name>
 			</font>
@@ -156,10 +156,10 @@ release the cable if necessary to remain terrain terrain clearance! </label>
 				<command>nasal</command>
 				<script>dragrobot.resetRobotAttributes()</script>
 			</binding>
-			<binding>
+			<!-- binding>
 				<command>nasal</command>
 				<script>dragrobot.resetTowing()</script>
-			</binding>
+			</binding --> <!-- resetTowing() does not exist anywhere -->
 		</button>
 		<empty>
 			<pref-height>6</pref-height>

--- a/gui/dialogs/dragrobot_advanced.xml
+++ b/gui/dialogs/dragrobot_advanced.xml
@@ -16,7 +16,7 @@
       <stretch>true</stretch>
     </empty>
     <text>
-      <label>Drag Roboter Advanced Configuration</label>
+      <label>Drag Robot Advanced Configuration</label>
       <font>
         <name>times_bold</name>
       </font>
@@ -397,7 +397,7 @@
       <legend>Reset</legend>
       <binding>
         <command>nasal</command>
-        <script>dg101g.resetRobotAttributes()</script>
+        <script>dragrobot.resetRobotAttributes()</script>
       </binding>
     </button>
     <empty>

--- a/gui/dialogs/electrical.xml
+++ b/gui/dialogs/electrical.xml
@@ -66,7 +66,7 @@
             <border>2</border>
             <binding>
                 <command>nasal</command>
-		<script>ls4.recharge_battery()</script>
+		<script>electrical.recharge_battery()</script>
             </binding>
     </button>
     <hrule/>


### PR DESCRIPTION
Battery recharge to 100% dialog button will now work instead of throwing an error.